### PR TITLE
docs(readme): update gtmc's domain

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -10,7 +10,7 @@
 
 > Un glosario multilingüe de términos técnicos de Minecraft, pensado para ayudar a jugadores, desarrolladores y traductores a mantener una terminología coherente entre idiomas.
 
-[Explorar el glosario en línea](http://beta.techmc.wiki/glossary) · [Ver el CSV fuente](https://github.com/DuskScorpio/TechMC-Glossary/blob/main/TechMC%20Glossary.csv)
+[Explorar el glosario en línea](https://techmc.wiki/glossary) · [Ver el CSV fuente](https://github.com/DuskScorpio/TechMC-Glossary/blob/main/TechMC%20Glossary.csv)
 
 </div>
 
@@ -56,7 +56,7 @@ synonym:Bounding Box; synonym:Hitbox; see:Collision Box
 ## Cómo contribuir
 
 > [!TIP]
-> Para la mayoría de las ediciones, el **[editor web en beta.techmc.wiki/glossary](http://beta.techmc.wiki/glossary)** es la opción más cómoda y la recomendada. Para cambios complejos o grandes, sigue siendo recomendable trabajar en local con `git` y el repositorio clonado.
+> Para la mayoría de las ediciones, el **[editor web en techmc.wiki/glossary](https://techmc.wiki/glossary)** es la opción más cómoda y la recomendada. Para cambios complejos o grandes, sigue siendo recomendable trabajar en local con `git` y el repositorio clonado.
 
 Si prefieres trabajar directamente con el archivo:
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 > A multilingual glossary of Minecraft technical terms, helping players, developers, and translators keep terminology consistent across languages.
 
-[Browse the glossary online](http://beta.techmc.wiki/glossary) · [View the source CSV](https://github.com/DuskScorpio/TechMC-Glossary/blob/main/TechMC%20Glossary.csv)
+[Browse the glossary online](https://techmc.wiki/glossary) · [View the source CSV](https://github.com/DuskScorpio/TechMC-Glossary/blob/main/TechMC%20Glossary.csv)
 
 </div>
 
@@ -56,7 +56,7 @@ synonym:Bounding Box; synonym:Hitbox; see:Collision Box
 ## Contributing
 
 > [!TIP]
-> For most edits, the **[web editor at beta.techmc.wiki/glossary](http://beta.techmc.wiki/glossary)** is the most convenient option and is recommended. For complex or large changes, working locally with `git` and the cloned repository is still advised.
+> For most edits, the **[web editor at techmc.wiki/glossary](https://techmc.wiki/glossary)** is the most convenient option and is recommended. For complex or large changes, working locally with `git` and the cloned repository is still advised.
 
 If you'd rather work with the file directly:
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -10,7 +10,7 @@
 
 > Многоязычный глоссарий технических терминов Minecraft, помогающий игрокам, разработчикам и переводчикам сохранять единообразие терминологии в разных языках.
 
-[Открыть глоссарий онлайн](http://beta.techmc.wiki/glossary) · [Посмотреть исходный CSV](https://github.com/DuskScorpio/TechMC-Glossary/blob/main/TechMC%20Glossary.csv)
+[Открыть глоссарий онлайн](https://techmc.wiki/glossary) · [Посмотреть исходный CSV](https://github.com/DuskScorpio/TechMC-Glossary/blob/main/TechMC%20Glossary.csv)
 
 </div>
 
@@ -56,7 +56,7 @@ synonym:Bounding Box; synonym:Hitbox; see:Collision Box
 ## Как внести вклад
 
 > [!TIP]
-> Для большинства правок **[веб-редактор на beta.techmc.wiki/glossary](http://beta.techmc.wiki/glossary)** — самый удобный вариант и рекомендуется к использованию. Для сложных или крупных изменений по-прежнему рекомендуется работать локально с `git` и клонированным репозиторием.
+> Для большинства правок **[веб-редактор на techmc.wiki/glossary](https://techmc.wiki/glossary)** — самый удобный вариант и рекомендуется к использованию. Для сложных или крупных изменений по-прежнему рекомендуется работать локально с `git` и клонированным репозиторием.
 
 Если вы предпочитаете работать с файлом напрямую:
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -10,7 +10,7 @@
 
 > Minecraft 技术术语的多语言对照表，帮助技术玩家、开发者与翻译者在不同语言中保持术语一致。
 
-[在线浏览术语表](http://beta.techmc.wiki/glossary) · [查看源 CSV 文件](https://github.com/DuskScorpio/TechMC-Glossary/blob/main/TechMC%20Glossary.csv)
+[在线浏览术语表](https://techmc.wiki/glossary) · [查看源 CSV 文件](https://github.com/DuskScorpio/TechMC-Glossary/blob/main/TechMC%20Glossary.csv)
 
 </div>
 
@@ -56,7 +56,7 @@ synonym:Bounding Box; synonym:Hitbox; see:Collision Box
 ## 参与贡献
 
 > [!TIP]
-> 对于大多数改动，使用 **[beta.techmc.wiki/glossary 在线编辑器](http://beta.techmc.wiki/glossary)** 是最便捷的方式，推荐使用。对于较复杂或大规模的修改，仍建议在本地使用 `git` 克隆仓库后进行编辑。
+> 对于大多数改动，使用 **[techmc.wiki/glossary 在线编辑器](https://techmc.wiki/glossary)** 是最便捷的方式，推荐使用。对于较复杂或大规模的修改，仍建议在本地使用 `git` 克隆仓库后进行编辑。
 
 如果你想直接修改文件：
 


### PR DESCRIPTION
GTMC is no longer in beta. This PR replaces <https://beta.techmc.wiki> with <https://techmc.wiki>.
